### PR TITLE
Handling when `{"openAccessPdf": None}` with `openaccess_scraper`

### DIFF
--- a/paperscraper/lib.py
+++ b/paperscraper/lib.py
@@ -196,12 +196,13 @@ async def pubmed_scraper(paper, path, session):
 
 
 async def openaccess_scraper(paper, path, session):
-    url = paper.get("openAccessPdf", {}).get("url")
+    # NOTE: paper may not have the key 'openAccessPdf', or its value may be None
+    url = (paper.get("openAccessPdf") or {}).get("url")
     if not url:
         return False
-    else:
-        await link_to_pdf(url, path, session)
-        return True
+    await link_to_pdf(url, path, session)
+    return True
+
 
 async def local_scraper(paper, path):
     return True

--- a/tests/test_paperscraper.py
+++ b/tests/test_paperscraper.py
@@ -1,9 +1,11 @@
+from unittest.mock import MagicMock
+
 import paperscraper
 import os
 from unittest import IsolatedAsyncioTestCase
 from paperscraper.utils import ThrottledClientSession
 from paperscraper.headers import get_header
-from paperscraper.lib import clean_upbibtex
+from paperscraper.lib import clean_upbibtex, openaccess_scraper
 from pybtex.database import parse_string
 from paperscraper.exceptions import DOINotFoundError
 
@@ -48,6 +50,8 @@ class Test1(IsolatedAsyncioTestCase):
         assert paperscraper.check_pdf(path)
         os.remove(path)
 
+    async def test_openaccess_scraper(self) -> None:
+        assert not await openaccess_scraper({"openAccessPdf": None}, MagicMock(), MagicMock())
 
     async def test_pubmed_to_pdf(self):
         path = "test.pdf"


### PR DESCRIPTION
It's possible that `paper = {"openAccessPdf": None, ...}`, but this breaks our current `openaccess_scraper`.

This PR fixes that, and adds a brief test case for it