### PR TITLE
Addition of `ruff`, `codespell`, `toml-sort`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,3 +21,12 @@ repos:
     rev: 24.2.0
     hooks:
     - id: black-jupyter
+  - repo: https://github.com/pappasam/toml-sort
+    rev: v0.23.1
+    hooks:
+      - id: toml-sort-fix
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.2.6
+    hooks:
+      - id: codespell
+        additional_dependencies: [".[toml]"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,6 +21,11 @@ repos:
     rev: 24.2.0
     hooks:
     - id: black-jupyter
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.3.1
+    hooks:
+      - id: ruff
+        args: [--fix, --exit-non-zero-on-fix]
   - repo: https://github.com/pappasam/toml-sort
     rev: v0.23.1
     hooks:

--- a/paperscraper/__init__.py
+++ b/paperscraper/__init__.py
@@ -1,14 +1,16 @@
-from .version import __version__
+# ruff: noqa: F401
+
+from .exceptions import DOINotFoundError
 from .lib import (
-    format_bibtex,
-    arxiv_to_pdf,
-    pmc_to_pdf,
     a_search_papers,
-    search_papers,
-    link_to_pdf,
-    pubmed_to_pdf,
+    arxiv_to_pdf,
     default_scraper,
+    format_bibtex,
+    link_to_pdf,
+    pmc_to_pdf,
+    pubmed_to_pdf,
+    search_papers,
 )
 from .scraper import Scraper
 from .utils import check_pdf
-from .exceptions import DOINotFoundError
+from .version import __version__

--- a/paperscraper/headers.py
+++ b/paperscraper/headers.py
@@ -1,5 +1,7 @@
 import random
 
+# ruff: noqa: E501
+
 user_agents = """
 Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Ubuntu Chromium/37.0.2062.94 Chrome/37.0.2062.94 Safari/537.36
 Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/45.0.2454.85 Safari/537.36

--- a/paperscraper/lib.py
+++ b/paperscraper/lib.py
@@ -388,7 +388,7 @@ async def a_search_papers(
                                 if res["file_format"] == "PDF":
                                     google_pdf_links[i] = res["link"]
 
-                # want this sepearate, since ss is rate_limit for google
+                # want this separate, since ss is rate_limit for google
                 async with ThrottledClientSession(
                     rate_limit=90 if "x-api-key" in ssheader else 15 / 60,
                     headers=ssheader,
@@ -486,7 +486,7 @@ async def a_search_papers(
                     )
                 return None, None
 
-            # batch them, since since we may reach desired limit before all done
+            # batch them, since we may reach desired limit before all done
             for i in range(0, len(papers), batch_size):
                 batch = papers[i : i + batch_size]
                 results = await asyncio.gather(

--- a/paperscraper/log_formatter.py
+++ b/paperscraper/log_formatter.py
@@ -12,7 +12,7 @@ class CustomFormatter(logging.Formatter):
         "%(asctime)s - %(name)s - %(levelname)s - %(message)s (%(filename)s:%(lineno)d)"
     )
 
-    FORMATS = {
+    FORMATS = {  # noqa: RUF012
         logging.DEBUG: grey + format + reset,
         logging.INFO: grey + format + reset,
         logging.WARNING: yellow + format + reset,

--- a/paperscraper/scraper.py
+++ b/paperscraper/scraper.py
@@ -43,10 +43,12 @@ class Scraper:
         # reshape sorted scrapers
         sorted_scrapers = []
         for priority in sorted({s.priority for s in self.scrapers}):
-            sorted_scrapers.append([s for s in self.scrapers if s.priority == priority])
+            sorted_scrapers.append(  # noqa: PERF401
+                [s for s in self.scrapers if s.priority == priority]
+            )
         self.sorted_scrapers = sorted_scrapers
 
-    async def scrape(self, paper, path, i=0, logger=None) -> bool:
+    async def scrape(self, paper, path, i=0, logger=None) -> bool:  # noqa: D417
         """Scrape a paper which contains data from Semantic Scholar API.
 
         Args:
@@ -58,7 +60,7 @@ class Scraper:
         scrape_result = {s.name: "none" for s in self.scrapers}
         for scrapers in self.sorted_scrapers[::-1]:
             for j in range(len(scrapers)):
-                j = (j + i) % len(scrapers)
+                j = (j + i) % len(scrapers)  # noqa: PLW2901
                 scraper = scrapers[j]
                 try:
                     result = await scraper.function(paper, path, **scraper.kwargs)

--- a/paperscraper/scraper.py
+++ b/paperscraper/scraper.py
@@ -1,6 +1,7 @@
+from dataclasses import dataclass
+
 from .headers import get_header
 from .utils import ThrottledClientSession, check_pdf
-from dataclasses import dataclass
 
 
 @dataclass
@@ -41,7 +42,7 @@ class Scraper:
         self.scrapers.sort(key=lambda x: x.priority, reverse=True)
         # reshape sorted scrapers
         sorted_scrapers = []
-        for priority in sorted(set([s.priority for s in self.scrapers])):
+        for priority in sorted({s.priority for s in self.scrapers}):
             sorted_scrapers.append([s for s in self.scrapers if s.priority == priority])
         self.sorted_scrapers = sorted_scrapers
 
@@ -76,6 +77,7 @@ class Scraper:
                 scrape_result[scraper.name] = "failed"
             if self.callback is not None:
                 await self.callback(paper["title"], scrape_result)
+        return None
 
     async def close(self):
         for scraper in self.scrapers:

--- a/paperscraper/utils.py
+++ b/paperscraper/utils.py
@@ -22,7 +22,9 @@ class ThrottledClientSession(aiohttp.ClientSession):
 
     MIN_SLEEP = 0.1
 
-    def __init__(self, rate_limit: Optional[float] = None, *args, **kwargs) -> None:
+    def __init__(
+        self, rate_limit: Optional[float] = None, *args, **kwargs  # noqa: FA100
+    ) -> None:
         # rate_limit - per second
         super().__init__(*args, **kwargs)
         self.rate_limit = rate_limit
@@ -35,7 +37,7 @@ class ThrottledClientSession(aiohttp.ClientSession):
             self._queue = asyncio.Queue(min(2, int(rate_limit) + 1))
             self._fillerTask = asyncio.create_task(self._filler(rate_limit))
 
-    def _get_sleep(self) -> Optional[float]:
+    def _get_sleep(self) -> Optional[float]:  # noqa: FA100
         if self.rate_limit is not None:
             return max(1 / self.rate_limit, self.MIN_SLEEP)
         return None
@@ -107,7 +109,7 @@ def check_pdf(path, verbose=False):
     if not os.path.exists(path):
         return False
     try:
-        pdf = pypdf.PdfReader(path)
+        pdf = pypdf.PdfReader(path)  # noqa: F841
     except (pypdf.errors.PyPdfError, ValueError) as e:
         if verbose:
             print(f"PDF at {path} is corrupt: {e}")

--- a/paperscraper/utils.py
+++ b/paperscraper/utils.py
@@ -1,15 +1,17 @@
 import asyncio
+import contextlib
 import os
+import random
 import time
 from typing import Optional
-import random
+
 import aiohttp
 import pypdf
 
 
 class ThrottledClientSession(aiohttp.ClientSession):
     """
-    Rate-throttled client session class inherited from aiohttp.ClientSession)
+    Rate-throttled client session class inherited from aiohttp.ClientSession).
 
     USAGE:
         replace `session = aiohttp.ClientSession()`
@@ -20,7 +22,7 @@ class ThrottledClientSession(aiohttp.ClientSession):
 
     MIN_SLEEP = 0.1
 
-    def __init__(self, rate_limit: float = None, *args, **kwargs) -> None:
+    def __init__(self, rate_limit: Optional[float] = None, *args, **kwargs) -> None:
         # rate_limit - per second
         super().__init__(*args, **kwargs)
         self.rate_limit = rate_limit
@@ -39,17 +41,15 @@ class ThrottledClientSession(aiohttp.ClientSession):
         return None
 
     async def close(self) -> None:
-        """Close rate-limiter's "bucket filler" task"""
+        """Close rate-limiter's "bucket filler" task."""
         if self._fillerTask is not None:
             self._fillerTask.cancel()
-        try:
+        with contextlib.suppress(asyncio.TimeoutError):
             await asyncio.wait_for(self._fillerTask, timeout=0.5)
-        except asyncio.TimeoutError as err:
-            pass
         await super().close()
 
     async def _filler(self, rate_limit: float = 1):
-        """Filler task to fill the leaky bucket algo"""
+        """Filler task to fill the leaky bucket algo."""
         try:
             if self._queue is None:
                 return
@@ -58,7 +58,7 @@ class ThrottledClientSession(aiohttp.ClientSession):
             updated_at = time.monotonic()
             fraction = 0
             extra_increment = 0
-            for i in range(0, self._queue.maxsize):
+            for i in range(self._queue.maxsize):
                 self._queue.put_nowait(i)
             while True:
                 if not self._queue.full():
@@ -73,7 +73,7 @@ class ThrottledClientSession(aiohttp.ClientSession):
                         )
                     )
                     fraction = fraction % 1
-                    for i in range(0, items_2_add):
+                    for i in range(items_2_add):
                         self._queue.put_nowait(i)
                     updated_at = now
                 await asyncio.sleep(sleep)
@@ -89,18 +89,13 @@ class ThrottledClientSession(aiohttp.ClientSession):
             #    self._start_time = time.time()
             await self._queue.get()
             self._queue.task_done()
-        return None
 
     async def _request(self, *args, **kwargs) -> aiohttp.ClientResponse:
-        """Throttled _request()"""
-        for retries in range(0, 5):
+        """Throttled _request()."""
+        for retries in range(5):
             await self._allow()
             response = await super()._request(*args, **kwargs)
-            if response and (
-                response.status == 429
-                or response.status == 503
-                or response.status == 504
-            ):
+            if response and (response.status in (429, 503, 504)):
                 # some service limit reached
                 await asyncio.sleep((2**retries) * 0.1 + random.random() * 0.1)
                 continue

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,13 @@
+[tool.codespell]
+check-filenames = true
+check-hidden = true
+# SEE: https://github.com/codespell-project/codespell/issues/1212#issuecomment-1744768533
+ignore-regex = ".{1024}|.*codespell-ignore.*"
+ignore-words-list = "cros,ser"
+
+[tool.tomlsort]
+all = true
+in_place = true
+spaces_before_inline_comment = 2  # Match Python PEP 8
+spaces_indent_inline_array = 4  # Match Python PEP 8
+trailing_comma_inline_array = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,85 @@ check-hidden = true
 ignore-regex = ".{1024}|.*codespell-ignore.*"
 ignore-words-list = "cros,ser"
 
+[tool.ruff]
+# Line length to use when enforcing long-lines violations (like `E501`).
+line-length = 97  # ceil(1.1 * 88) makes `E501` equivalent to `B950`
+# Enable application of unsafe fixes.
+unsafe-fixes = true
+
+[tool.ruff.lint]
+# List of rule codes that are unsupported by Ruff, but should be preserved when
+# (e.g.) validating # noqa directives. Useful for retaining # noqa directives
+# that cover plugins not yet implemented by Ruff.
+ignore = [
+    "ANN",  # Don't care to enforce typing
+    "BLE001",  # Don't care to enforce blind exception catching
+    "COM812",  # Trailing comma with black leads to wasting lines
+    "D100",  # D100, D101, D102, D103, D104, D105, D106, D107: don't always need docstrings
+    "D101",
+    "D102",
+    "D103",
+    "D104",
+    "D105",
+    "D106",
+    "D107",
+    "D203",  # Keep docstring next to the class definition (covered by D211)
+    "D212",  # Summary should be on second line (opposite of D213)
+    "D402",  # It's nice to reuse the method name
+    "D406",  # Google style requires ":" at end
+    "D407",  # We aren't using numpy style
+    "D413",  # Blank line after last section. -> No blank line
+    "DTZ",  # Don't care to have timezone safety
+    "EM",  # Overly pedantic
+    "ERA001",  # Don't care to prevent commented code
+    "FBT001",  # FBT001, FBT002: overly pedantic
+    "FBT002",
+    "FIX",  # Don't care to prevent TODO, FIXME, etc.
+    "FLY002",  # Can be less readable
+    "G004",  # f-strings are convenient
+    "INP001",  # Can use namespace packages
+    "N803",  # Want to use 'N', or 'L',
+    "N806",  # Want to use 'N', or 'L',
+    "PLR0913",
+    "PTH",  # Overly pedantic
+    "S311",  # Ok to use python random
+    "SLF001",  # Overly pedantic
+    "T201",  # Overly pedantic
+    "TCH001",  # TCH001, TCH002, TCH003: don't care to enforce type checking blocks
+    "TCH002",
+    "TCH003",
+    "TD002",  # Don't care for TODO author
+    "TD003",  # Don't care for TODO links
+    "TID252",  # Allow relative imports for packaging
+    "TRY003",  # Overly pedantic
+]
+select = ["ALL"]
+unfixable = [
+    "B007",  # While debugging, unused loop variables can be useful
+    "ERA001",  # While debugging, temporarily commenting code can be useful
+    "F401",  # While debugging, unused imports can be useful
+    "F841",  # While debugging, unused locals can be useful
+]
+
+[tool.ruff.lint.flake8-annotations]
+mypy-init-return = true
+
+[tool.ruff.lint.per-file-ignores]
+"tests/*.py" = [
+    "PLR2004",  # Tests can have magic values
+    "S101",  # Tests can have assertions
+]
+
+[tool.ruff.lint.pycodestyle]
+# The maximum line length to allow for line-length violations within
+# documentation (W505), including standalone comments.
+max-doc-length = 97  # Match line-length
+
+[tool.ruff.lint.pydocstyle]
+# Whether to use Google-style or NumPy-style conventions or the PEP257
+# defaults when analyzing docstring sections.
+convention = "google"
+
 [tool.tomlsort]
 all = true
 in_place = true

--- a/setup.py
+++ b/setup.py
@@ -2,12 +2,12 @@ from setuptools import setup
 
 exec(open("paperscraper/version.py").read())
 
-with open("README.md", "r", encoding="utf-8") as fh:
+with open("README.md", encoding="utf-8") as fh:
     long_description = fh.read()
 
 setup(
     name="paper-scraper",
-    version=__version__,
+    version=__version__,  # noqa: F821
     description="LLM Chain for answering questions from docs ",
     author="blackadad",
     author_email="hello@futureforecasts.io",

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-exec(open("paperscraper/version.py").read())
+exec(open("paperscraper/version.py").read())  # noqa: S102, SIM115
 
 with open("README.md", encoding="utf-8") as fh:
     long_description = fh.read()
@@ -25,4 +25,3 @@ setup(
         "Operating System :: OS Independent",
     ],
 )
-1

--- a/tests/test_paperscraper.py
+++ b/tests/test_paperscraper.py
@@ -86,7 +86,7 @@ class Test1(IsolatedAsyncioTestCase):
             os.remove(path)
 
         except RuntimeError as e:
-            assert "403" in str(e)
+            assert "403" in str(e)  # noqa: PT017
 
     async def test_link3_to_pdf(self):
         link = "https://www.medrxiv.org/content/medrxiv/early/2020/03/23/2020.03.20.20040055.full.pdf"
@@ -153,7 +153,10 @@ class Test7(IsolatedAsyncioTestCase):
         query = "covid vaccination"
         scraper = paperscraper.Scraper()
         scraper = scraper.register_scraper(
-            lambda paper, path, **kwargs: None, priority=0, name="test", check=False
+            lambda paper, path, **kwargs: None,  # noqa: ARG005
+            priority=0,
+            name="test",
+            check=False,
         )
         papers = await paperscraper.a_search_papers(query, limit=5, scraper=scraper)
         assert len(papers) >= 5
@@ -171,12 +174,14 @@ class Test9(IsolatedAsyncioTestCase):
         # make sure default scraper doesn't duplicate scrapers
         scraper = paperscraper.default_scraper()
 
-        async def callback(paper, result):
+        async def callback(paper, result):  # noqa: ARG001
             assert len(result) > 5
             print(result)
 
         scraper.callback = callback
-        papers = await paperscraper.a_search_papers("test", limit=1, scraper=scraper)
+        papers = await paperscraper.a_search_papers(  # noqa: F841
+            "test", limit=1, scraper=scraper
+        )
         await scraper.close()
 
 
@@ -222,17 +227,17 @@ class Test13(IsolatedAsyncioTestCase):
 class Test14(IsolatedAsyncioTestCase):
     async def test_scraper_doi_search(self):
         try:
-            papers = await paperscraper.a_search_papers(
+            papers = await paperscraper.a_search_papers(  # noqa: F841
                 "10.23919/eusipco55093.2022.9909972", limit=1, search_type="doi"
             )
         except Exception as e:
-            assert isinstance(e, DOINotFoundError)
+            assert isinstance(e, DOINotFoundError)  # noqa: PT017
 
 
 class Test15(IsolatedAsyncioTestCase):
     async def test_pdf_link_from_google(self):
         papers = await paperscraper.a_search_papers(
-            "Multiplex Base Editing to Protect from CD33-Directed Therapy: Implications for Immune and Gene Therapy",
+            "Multiplex Base Editing to Protect from CD33-Directed Therapy: Implications for Immune and Gene Therapy",  # noqa: E501
             limit=1,
             search_type="google",
         )
@@ -253,8 +258,8 @@ class Test16(IsolatedAsyncioTestCase):
                 volume = {9 9},
                 year = {2013}
             }
-        """
-        text = "Romelia Salomón-Ferrer, A. Götz, D. Poole, S. Le Grand, and R. Walker. Routine microsecond molecular dynamics simulations with amber on gpus. 2. explicit solvent particle mesh ewald. Journal of chemical theory and computation, 9 9:3878-88, 2013."
+        """  # noqa: E501
+        text = "Romelia Salomón-Ferrer, A. Götz, D. Poole, S. Le Grand, and R. Walker. Routine microsecond molecular dynamics simulations with amber on gpus. 2. explicit solvent particle mesh ewald. Journal of chemical theory and computation, 9 9:3878-88, 2013."  # noqa: E501
         assert paperscraper.format_bibtex(bibtex, "Salomón-Ferrer2013RoutineMM") == text
 
         bibtex2 = """
@@ -267,7 +272,7 @@ class Test16(IsolatedAsyncioTestCase):
             volume = {39},
             year = {2019}
             }
-        """
+        """  # noqa: E501
 
         parse_string(clean_upbibtex(bibtex2), "bibtex")
 
@@ -281,7 +286,7 @@ class Test16(IsolatedAsyncioTestCase):
             volume = {39},
             year = {2019}
         }
-        """
+        """  # noqa: E501
 
         parse_string(clean_upbibtex(bibtex3), "bibtex")
 
@@ -295,7 +300,7 @@ class Test16(IsolatedAsyncioTestCase):
             volume = {39},
             year = {2019}
         }
-        """
+        """  # noqa: E501
 
         parse_string(clean_upbibtex(bibtex4), "bibtex")
 

--- a/tests/test_paperscraper.py
+++ b/tests/test_paperscraper.py
@@ -1,13 +1,14 @@
-from unittest.mock import MagicMock
-
-import paperscraper
 import os
 from unittest import IsolatedAsyncioTestCase
-from paperscraper.utils import ThrottledClientSession
+from unittest.mock import MagicMock
+
+from pybtex.database import parse_string
+
+import paperscraper
+from paperscraper.exceptions import DOINotFoundError
 from paperscraper.headers import get_header
 from paperscraper.lib import clean_upbibtex, openaccess_scraper
-from pybtex.database import parse_string
-from paperscraper.exceptions import DOINotFoundError
+from paperscraper.utils import ThrottledClientSession
 
 
 class Test0(IsolatedAsyncioTestCase):


### PR DESCRIPTION
Adds tools with configs, and uses `ruff --add-noqa` to enable `pre-commit run -a` to pass.