### PR TITLE
Introducing basic CI pipeline

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -1,0 +1,22 @@
+---
+name: Lint and Test
+
+on: # yamllint disable-line rule:truthy
+  pull_request:
+  push:
+    branches: ["main"]
+
+permissions:
+  contents: read
+
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          cache: "pip"
+      - run: python -m pip install . -r dev-requirements.txt
+      - uses: pre-commit/action@v3.0.1
+      - run: pytest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
     hooks:
     - id: black-jupyter
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.3.1
+    rev: v0.3.2
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,13 @@ check-hidden = true
 ignore-regex = ".{1024}|.*codespell-ignore.*"
 ignore-words-list = "cros,ser"
 
+[tool.pytest.ini_options]
+# List of directories that should be searched for tests when no specific directories,
+# files or test ids are given in the command line when executing pytest from the rootdir
+# directory. File system paths may use shell-style wildcards, including the recursive **
+# pattern.
+testpaths = ["tests"]
+
 [tool.ruff]
 # Line length to use when enforcing long-lines violations (like `E501`).
 line-length = 97  # ceil(1.1 * 88) makes `E501` equivalent to `B950`

--- a/tests/test_paperscraper.py
+++ b/tests/test_paperscraper.py
@@ -98,16 +98,6 @@ class Test1(IsolatedAsyncioTestCase):
         assert paperscraper.check_pdf(path)
         os.remove(path)
 
-    async def test_doi_to_pdf_open(self):
-        doi = "10.1002/elsc.201300021"
-        path = "test.pdf"
-        async with ThrottledClientSession(
-            headers=get_header(), rate_limit=15 / 60
-        ) as session:
-            await paperscraper.doi_to_pdf(doi, path, session)
-        assert paperscraper.check_pdf(path)
-        os.remove(path)
-
 
 class Test2(IsolatedAsyncioTestCase):
     async def test_search_papers(self):


### PR DESCRIPTION
- Added basic CI pipeline for `pre-commit` and `pytest` (with `pytest` config)
- Remove stale `test_doi_to_pdf_open`, stale since `doi_to_pdf` was removed in https://github.com/blackadad/paper-scraper/commit/a8f643c6a3d7f99addd969844a807b0336192e86
