### PR TITLE
Fixing CI after #35

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -16,7 +16,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          cache: "pip"
+          cache: pip
+          python-version: 3.12
       - run: python -m pip install . -r dev-requirements.txt
       - uses: pre-commit/action@v3.0.1
       - name: test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+build-backend = "setuptools.build_meta"
+requires = ["setuptools >= 61.0"]
+
 [project]
 authors = [
     {email = "hello@futureforecasts.io", name = "blackadad"},


### PR DESCRIPTION
https://github.com/blackadad/paper-scraper/actions/runs/8269280241/job/22624185015

CI failed because `setuptools==59.6.0` was installed, and version 61 is required for `pyproject.toml`.

This PR:
- Adds `setuptools` metadata requiring version 61 as detailed in https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#declaring-the-build-backend
- Pins CI to use Python 3.12 (ensuring a later `setuptools`) is present anyways