### PR TITLE
Allowing `check_pdf` to accept a `Logger`

### DIFF
--- a/paperscraper/scraper.py
+++ b/paperscraper/scraper.py
@@ -81,7 +81,9 @@ class Scraper:
                 scraper = scrapers[(i + j) % len(scrapers)]
                 try:
                     result = await scraper.function(paper, path, **scraper.kwargs)
-                    if result and (not scraper.check_pdf or check_pdf(path)):
+                    if result and (
+                        not scraper.check_pdf or check_pdf(path, logger or False)
+                    ):
                         scrape_result[scraper.name] = "success"
                         if logger is not None:
                             logger.debug(

--- a/paperscraper/scraper.py
+++ b/paperscraper/scraper.py
@@ -92,9 +92,9 @@ class Scraper:
                         if self.callback is not None:
                             await self.callback(paper["title"], scrape_result)
                         return True
-                except Exception as e:
+                except Exception:
                     if logger is not None:
-                        logger.info(f"\tScraper {scraper.name} failed: {e}")
+                        logger.exception(f"\tScraper {scraper.name} failed.")
                 scrape_result[scraper.name] = "failed"
             if self.callback is not None:
                 await self.callback(paper["title"], scrape_result)

--- a/paperscraper/utils.py
+++ b/paperscraper/utils.py
@@ -112,9 +112,9 @@ def check_pdf(path, verbose: Union[bool, Logger] = False) -> bool:  # noqa: FA10
     try:
         pdf = pypdf.PdfReader(path)  # noqa: F841
     except (pypdf.errors.PyPdfError, ValueError) as e:
-        if verbose:
-            (print if isinstance(verbose, bool) else verbose.error)(
-                f"PDF at {path} is corrupt: {e}"
-            )
+        if verbose and isinstance(verbose, bool):
+            print(f"PDF at {path} is corrupt: {e}")
+        elif verbose:
+            verbose.exception(f"PDF at {path} is corrupt.", exc_info=e)
         return False
     return True

--- a/paperscraper/utils.py
+++ b/paperscraper/utils.py
@@ -3,7 +3,8 @@ import contextlib
 import os
 import random
 import time
-from typing import Optional
+from logging import Logger
+from typing import Optional, Union
 
 import aiohttp
 import pypdf
@@ -105,13 +106,15 @@ class ThrottledClientSession(aiohttp.ClientSession):
         return response
 
 
-def check_pdf(path, verbose=False):
+def check_pdf(path, verbose: Union[bool, Logger] = False) -> bool:  # noqa: FA100
     if not os.path.exists(path):
         return False
     try:
         pdf = pypdf.PdfReader(path)  # noqa: F841
     except (pypdf.errors.PyPdfError, ValueError) as e:
         if verbose:
-            print(f"PDF at {path} is corrupt: {e}")
+            (print if isinstance(verbose, bool) else verbose.error)(
+                f"PDF at {path} is corrupt: {e}"
+            )
         return False
     return True


### PR DESCRIPTION
This PR:
- Enables `check_pdf` to log failures
- Uses `Logger.exception` to better log failures