### PR TITLE
Exposing paper search and paper recommendations URLs

### DIFF
--- a/paperscraper/headers.py
+++ b/paperscraper/headers.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import random
 
 # ruff: noqa: E501
@@ -1006,9 +1008,9 @@ Mozilla/5.0 (iPhone; CPU iPhone OS 8_4 like Mac OS X) AppleWebKit/600.1.4 (KHTML
 """
 
 
-def get_user_agent():
+def get_user_agent() -> str:
     return random.choice(user_agents.splitlines())
 
 
-def get_header():
+def get_header() -> dict[str, str]:
     return {"User-Agent": get_user_agent()}

--- a/paperscraper/lib.py
+++ b/paperscraper/lib.py
@@ -259,6 +259,7 @@ SEMANTIC_SCHOLAR_API_FIELDS: str = ",".join(
         "title",
     ]
 )
+SEMANTIC_SCHOLAR_BASE_URL = "https://api.semanticscholar.org"
 
 
 async def a_search_papers(  # noqa: C901, PLR0912, PLR0915
@@ -288,23 +289,25 @@ async def a_search_papers(  # noqa: C901, PLR0912, PLR0915
             logger.addHandler(ch)
     params = {"fields": SEMANTIC_SCHOLAR_API_FIELDS}
     if search_type == "default":
-        endpoint = "https://api.semanticscholar.org/graph/v1/paper/search"
+        endpoint = f"{SEMANTIC_SCHOLAR_BASE_URL}/graph/v1/paper/search"
         params["query"] = query.replace("-", " ")
         params["offset"] = _offset
         params["limit"] = _limit
     elif search_type == "paper":
-        endpoint = f"https://api.semanticscholar.org/recommendations/v1/papers/forpaper/{query}"
+        endpoint = (
+            f"{SEMANTIC_SCHOLAR_BASE_URL}/recommendations/v1/papers/forpaper/{query}"
+        )
         params["limit"] = _limit
     elif search_type == "doi":
-        endpoint = f"https://api.semanticscholar.org/graph/v1/paper/DOI:{query}"
+        endpoint = f"{SEMANTIC_SCHOLAR_BASE_URL}/graph/v1/paper/DOI:{query}"
     elif search_type == "future_citations":
-        endpoint = f"https://api.semanticscholar.org/graph/v1/paper/{query}/citations"
+        endpoint = f"{SEMANTIC_SCHOLAR_BASE_URL}/graph/v1/paper/{query}/citations"
         params["limit"] = _limit
     elif search_type == "past_references":
-        endpoint = f"https://api.semanticscholar.org/graph/v1/paper/{query}/references"
+        endpoint = f"{SEMANTIC_SCHOLAR_BASE_URL}/graph/v1/paper/{query}/references"
         params["limit"] = _limit
     elif search_type == "google":
-        endpoint = "https://api.semanticscholar.org/graph/v1/paper/search"
+        endpoint = f"{SEMANTIC_SCHOLAR_BASE_URL}/graph/v1/paper/search"
         params["limit"] = 1
         google_endpoint = "https://serpapi.com/search.json"
         google_params = {

--- a/paperscraper/lib.py
+++ b/paperscraper/lib.py
@@ -266,7 +266,7 @@ async def a_search_papers(  # noqa: C901, PLR0912, PLR0915
     query,
     limit=10,
     pdir=os.curdir,
-    semantic_scholar_api_key=None,
+    semantic_scholar_api_key: str | None = None,
     _paths: dict[str | os.PathLike, dict[str, Any]] | None = None,
     _limit=100,
     _offset=0,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ name = "paper-scraper"
 readme = "README.md"
 requires-python = ">=3.8"
 urls = {repository = "https://github.com/blackadad/paper-scraper"}
-version = "1.4.0"
+version = "1.5.0"
 
 [tool.codespell]
 check-filenames = true

--- a/tests/test_paperscraper.py
+++ b/tests/test_paperscraper.py
@@ -179,7 +179,9 @@ class Test10(IsolatedAsyncioTestCase):
     async def test_scraper_paper_search(self):
         # make sure default scraper doesn't duplicate scrapers
         papers = await paperscraper.a_search_papers(
-            "649def34f8be52c8b66281af98ae884c09aef38b", limit=1, search_type="paper"
+            "649def34f8be52c8b66281af98ae884c09aef38b",
+            limit=1,
+            search_type="paper_recommendations",
         )
         assert len(papers) >= 1
 


### PR DESCRIPTION
- Decomposes out `SematicScholarSearchType` so it can be used elsewhere to make URLs
- Renames `papers` to `paper_recommendations` (to match its usage), and adds `papers` for actual papers query
- Adds type hints while reading the code