### PR TITLE
Fixing variable confusion in `response` vs `resp`

### DIFF
--- a/paperscraper/lib.py
+++ b/paperscraper/lib.py
@@ -537,8 +537,10 @@ async def a_search_papers(  # noqa: C901, PLR0912, PLR0915
                                         if not resp.ok:
                                             logger.warning(
                                                 "Error correlating papers from google"
-                                                "to semantic scholar (no year)"
-                                                f"{response.status} {response.reason} {await response.text()}"  # noqa: E501
+                                                " to semantic scholar (no year):"
+                                                f" status {resp.status},"
+                                                f" reason {resp.reason},"
+                                                f" text {await resp.text()!r}."
                                             )
                                         response = await resp.json()  # noqa: PLW2901
                             if "data" in response:


### PR DESCRIPTION
An accidental name swap results in this error message:

```none
2024-03-28 17:22:53.811 PDT
  File "/usr/local/lib/python3.12/site-packages/paperscraper/lib.py", line 436, in google2s2
2024-03-28 17:22:53.811 PDT
    f"{response.status} {response.reason} {await response.text()}"  # noqa: E501
2024-03-28 17:22:53.811 PDT
       ^^^^^^^^^^^^^^^
2024-03-28 17:22:54.406 PDT
AttributeError: 'dict' object has no attribute 'status'
```

This PR:
- Fixes missing spaces
- Fixes name confusion in `resp` vs `response`