### PR TITLE
Fixing `a_search_papers` more than 20 "google" search results

### DIFF
--- a/paperscraper/lib.py
+++ b/paperscraper/lib.py
@@ -319,7 +319,7 @@ async def parse_semantic_scholar_metadata(paper: dict[str, Any]) -> dict[str, An
 async def parse_google_scholar_metadata(
     paper: dict[str, Any], session: ClientSession
 ) -> dict[str, Any]:
-    """Parse raw paper metadata from google scholar into a more rich format."""
+    """Parse raw paper metadata from Google Scholar into a more rich format."""
     doi = paper["externalIds"].get("DOI", None)
     key = None
     if doi:
@@ -649,7 +649,7 @@ async def a_search_papers(  # noqa: C901, PLR0912, PLR0915
                             response = await resp.json()
                     if "data" in response:
                         if pdf_link is not None:
-                            # google scholar url takes precedence
+                            # Google Scholar url takes precedence
                             response["data"][0]["openAccessPdf"] = {"url": pdf_link}
                         return response["data"][0]
                     return None

--- a/paperscraper/lib.py
+++ b/paperscraper/lib.py
@@ -881,21 +881,7 @@ async def a_gsearch_papers(  # noqa: C901, PLR0915
     return paths
 
 
-def search_papers(
-    query,
-    limit=10,
-    pdir=os.curdir,
-    semantic_scholar_api_key=None,
-    _paths=None,
-    _limit=100,
-    _offset=0,
-    logger=None,
-    year=None,
-    verbose=False,
-    scraper=None,
-    batch_size=10,
-    search_type="default",
-):
+def search_papers(*a_search_args, **a_search_kwargs):
     # special case for jupyter notebooks
     if "get_ipython" in globals() or "google.colab" in sys.modules:
         import nest_asyncio
@@ -906,20 +892,4 @@ def search_papers(
     except RuntimeError as e:  # noqa: F841
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
-    return loop.run_until_complete(
-        a_search_papers(
-            query,
-            limit=limit,
-            pdir=pdir,
-            semantic_scholar_api_key=semantic_scholar_api_key,
-            _paths=_paths,
-            _limit=_limit,
-            _offset=_offset,
-            logger=logger,
-            year=year,
-            verbose=verbose,
-            scraper=scraper,
-            batch_size=batch_size,
-            search_type=search_type,
-        )
-    )
+    return loop.run_until_complete(a_search_papers(*a_search_args, **a_search_kwargs))

--- a/paperscraper/lib.py
+++ b/paperscraper/lib.py
@@ -336,13 +336,10 @@ async def parse_google_scholar_metadata(
         ) as r:
             r.raise_for_status()
             data = await r.json()
-            citation = next(
-                c["snippet"] for c in data["citations"] if c["title"] == "MLA"
-            )
-            bibtex_link = next(
-                c["link"] for c in data["links"] if c["name"] == "BibTeX"
-            )
+        citation = next(c["snippet"] for c in data["citations"] if c["title"] == "MLA")
+        bibtex_link = next(c["link"] for c in data["links"] if c["name"] == "BibTeX")
         async with session.get(bibtex_link) as r:
+            r.raise_for_status()
             bibtex = await r.text()
     return {
         "citation": citation,

--- a/paperscraper/lib.py
+++ b/paperscraper/lib.py
@@ -321,13 +321,12 @@ async def parse_google_scholar_metadata(
     paper: dict[str, Any], session: ClientSession
 ) -> dict[str, Any]:
     """Parse raw paper metadata from Google Scholar into a more rich format."""
-    doi = paper["externalIds"].get("DOI", None)
-    key = None
+    doi: str | None = paper["externalIds"].get("DOI", None)
     if doi:
         bibtex = await doi_to_bibtex(doi, session)
-        key = bibtex.split("{")[1].split(",")[0]
+        key: str = bibtex.split("{")[1].split(",")[0]
         citation = format_bibtex(bibtex, key, clean=False)
-    if key is None:
+    else:
         # get citation by following link
         # SLOW SLOW Using SerpAPI for this
         async with session.get(
@@ -341,6 +340,7 @@ async def parse_google_scholar_metadata(
         async with session.get(bibtex_link) as r:
             r.raise_for_status()
             bibtex = await r.text()
+        key = bibtex.split("{")[1].split(",")[0]
     return {
         "citation": citation,
         "key": key,

--- a/tests/test_paperscraper.py
+++ b/tests/test_paperscraper.py
@@ -81,22 +81,17 @@ def test_format_bibtex_badkey():
 
 
 class Test0(IsolatedAsyncioTestCase):
-    async def test_google_search_papers(self):
-        query = "molecular dynamics"
-        papers = await paperscraper.a_search_papers(
-            query, search_type="google", year="2019-2023", limit=5
-        )
-        assert len(papers) >= 3
-
-        query = "molecular dynamics"
-        papers = await paperscraper.a_search_papers(
-            query, search_type="google", year="2020", limit=5
-        )
-        assert len(papers) >= 3
-
-        query = "covid vaccination"
-        papers = await paperscraper.a_search_papers(query, search_type="google")
-        assert len(papers) >= 3
+    async def test_google_search_papers(self) -> None:
+        for query, year, limit in [
+            ("molecular dynamics", "2019-2023", 5),
+            ("molecular dynamics", "2020", 5),
+            ("covid vaccination", None, 10),
+        ]:
+            with self.subTest():
+                papers = await paperscraper.a_search_papers(
+                    query, search_type="google", year=year, limit=limit
+                )
+                assert len(papers) >= 3
 
 
 class TestGS(IsolatedAsyncioTestCase):

--- a/tests/test_paperscraper.py
+++ b/tests/test_paperscraper.py
@@ -93,6 +93,12 @@ class Test0(IsolatedAsyncioTestCase):
                 )
                 assert len(papers) >= 3
 
+    async def test_high_limit(self) -> None:
+        papers = await paperscraper.a_search_papers(
+            "molecular dynamics", search_type="google", year="2019-2023", limit=45
+        )
+        assert len(papers) > 20
+
 
 class TestGS(IsolatedAsyncioTestCase):
     async def test_gsearch(self):
@@ -109,6 +115,12 @@ class TestGS(IsolatedAsyncioTestCase):
             assert paper["paperId"]
             assert paper["citationCount"]
             assert paper["title"]
+
+    async def test_high_limit(self) -> None:
+        papers = await paperscraper.a_gsearch_papers(
+            "molecular dynamics", year="2019-2023", limit=45
+        )
+        assert len(papers) > 20
 
 
 class Test1(IsolatedAsyncioTestCase):


### PR DESCRIPTION
Revival of https://github.com/blackadad/paper-scraper/pull/51 after https://github.com/blackadad/paper-scraper/pull/47

This PR:

- Fixes a logic bug by pulling from SERP result if we should recurse, with added test case
    - Also makes the same test for `a_gsearch_papers`
- Fixes a separate logic bug that can result in empty `citation`
- Documents `a_search_papers`'s args, and removes signature duplication with `search_papers`
- Makes `pdir`'s be compatible with `Path`
- Denies `_limit` above 100, since this implementation doesn't properly handle Semantic Scholar pagination (`"next"`)