### PR TITLE
Various improvements to speed and errors

### DIFF
--- a/paperscraper/lib.py
+++ b/paperscraper/lib.py
@@ -344,7 +344,7 @@ async def parse_google_scholar_metadata(
         bibtex_link = next(c["link"] for c in data["links"] if c["name"] == "BibTeX")
         async with session.get(bibtex_link) as r:
             # we may have a 443 - link expired
-            if r.status == 443:  # noqa: PLR2004 
+            if r.status == 443:  # noqa: PLR2004
                 raise RuntimeError(f"443 on bibtex link at {bibtex_link}")
             r.raise_for_status()
             bibtex = await r.text()

--- a/paperscraper/lib.py
+++ b/paperscraper/lib.py
@@ -344,7 +344,7 @@ async def parse_google_scholar_metadata(
         bibtex_link = next(c["link"] for c in data["links"] if c["name"] == "BibTeX")
         async with session.get(bibtex_link) as r:
             # we may have a 443 - link expired
-            if r.status == 443: # noqa: PLR2004 
+            if r.status == 443:  # noqa: PLR2004 
                 raise RuntimeError(f"443 on bibtex link at {bibtex_link}")
             r.raise_for_status()
             bibtex = await r.text()

--- a/paperscraper/lib.py
+++ b/paperscraper/lib.py
@@ -344,7 +344,7 @@ async def parse_google_scholar_metadata(
         bibtex_link = next(c["link"] for c in data["links"] if c["name"] == "BibTeX")
         async with session.get(bibtex_link) as r:
             # we may have a 443 - link expired
-            if r.status == 443:
+            if r.status == 443: # noqa: PLR2004 
                 raise RuntimeError(f"443 on bibtex link at {bibtex_link}")
             r.raise_for_status()
             bibtex = await r.text()

--- a/paperscraper/lib.py
+++ b/paperscraper/lib.py
@@ -345,7 +345,7 @@ async def parse_google_scholar_metadata(
         async with session.get(bibtex_link) as r:
             # we may have a 443 - link expired
             if r.status == 443:
-                raise RuntimeError(f"Google scholar refused bibtex link at {bibtex_link}")
+                raise RuntimeError(f"443 on bibtex link at {bibtex_link}")
             r.raise_for_status()
             bibtex = await r.text()
         key = bibtex.split("{")[1].split(",")[0]
@@ -873,9 +873,7 @@ async def a_gsearch_papers(  # noqa: C901, PLR0915
                 paper["citationCount"] = int(paper["inline_links"]["cited_by"]["total"])
 
             # set paperId to be hex digest of doi
-            paper["paperId"] = hashlib.md5(  # noqa: S324
-                doi.encode()
-            ).hexdigest()[0:16]
+            paper["paperId"] = hashlib.md5(doi.encode()).hexdigest()[0:16]  # noqa: S324
             return paper
 
         # we only process papers that have a link

--- a/paperscraper/lib.py
+++ b/paperscraper/lib.py
@@ -345,7 +345,9 @@ async def parse_google_scholar_metadata(
         async with session.get(bibtex_link) as r:
             # we may have a 443 - link expired
             if r.status == 443:  # noqa: PLR2004
-                raise RuntimeError(f"443 on bibtex link at {bibtex_link}")
+                raise RuntimeError(
+                    f"Google scholar blocking bibtex link at {bibtex_link}"
+                )
             r.raise_for_status()
             bibtex = await r.text()
         key = bibtex.split("{")[1].split(",")[0]
@@ -395,7 +397,9 @@ async def doi_to_bibtex(doi: str, session: ClientSession) -> str:
     url = f"https://api.crossref.org/works/{doi}/transform/application/x-bibtex"
     async with session.get(url) as r:
         if not r.ok:
-            raise DOINotFoundError(f"Could not resolve DOI {doi}")
+            raise DOINotFoundError(
+                f"Per HTTP status code {r.status_code}, could not resolve DOI {doi}."
+            )
         data = await r.text()
     # must make new key
     key = data.split("{")[1].split(",")[0]

--- a/paperscraper/utils.py
+++ b/paperscraper/utils.py
@@ -112,9 +112,8 @@ def check_pdf(path: str, verbose: Union[bool, Logger] = False) -> bool:  # noqa:
             pass  # For now, just opening the file is our basic check
 
     except (
-        Exception
-    ) as e:  # Catching a general exception as fitz might throw various types of exceptions
-        # Handle the verbose logging or printing
+        fitz.FileDataError
+    ) as e: 
         if verbose and isinstance(verbose, bool):
             print(f"PDF at {path} is corrupt or unreadable: {e}")
         elif verbose:

--- a/paperscraper/utils.py
+++ b/paperscraper/utils.py
@@ -111,9 +111,7 @@ def check_pdf(path: str, verbose: Union[bool, Logger] = False) -> bool:  # noqa:
         with fitz.open(path) as _:
             pass  # For now, just opening the file is our basic check
 
-    except (
-        fitz.FileDataError
-    ) as e: 
+    except fitz.FileDataError as e:
         if verbose and isinstance(verbose, bool):
             print(f"PDF at {path} is corrupt or unreadable: {e}")
         elif verbose:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,9 +19,9 @@ classifiers = [
     "Programming Language :: Python",
 ]
 dependencies = [
-    "aiohttp",
-    "pybtex",
     "PyMuPDF",
+    "aiohttp",
+    "pybtex"
 ]
 description = "LLM Chain for answering questions from docs"
 keywords = ["question answering"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ name = "paper-scraper"
 readme = "README.md"
 requires-python = ">=3.8"
 urls = {repository = "https://github.com/blackadad/paper-scraper"}
-version = "1.6.1"
+version = "1.7.0"
 
 [tool.codespell]
 check-filenames = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 dependencies = [
     "PyMuPDF",
     "aiohttp",
-    "pybtex"
+    "pybtex",
 ]
 description = "LLM Chain for answering questions from docs"
 keywords = ["question answering"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 dependencies = [
     "aiohttp",
     "pybtex",
-    "pypdf",
+    "PyMuPDF",
 ]
 description = "LLM Chain for answering questions from docs"
 keywords = ["question answering"]

--- a/tests/test_paperscraper.py
+++ b/tests/test_paperscraper.py
@@ -116,7 +116,7 @@ class TestGS(IsolatedAsyncioTestCase):
             assert paper["citationCount"]
             assert paper["title"]
 
-    async def test_high_limit(self) -> None:
+    async def test_gsearch_high_limit(self) -> None:
         papers = await paperscraper.a_gsearch_papers(
             "molecular dynamics", year="2019-2023", limit=45
         )


### PR DESCRIPTION
* Replaces pypdf with PyMuPDF for speed
* Adds fallback to SerpAPI if cross-ref gives 404 for bibtex
* Greatly simplifies throttled client and fix logic on leaky bucket algo (I hope)
* **Changes paperId on gsearch to be based on DOI instead of link**


The throttled client was blindly copied from https://stackoverflow.com/questions/48682147/aiohttp-rate-limiting-parallel-requests/60357775#60357775 which turns out to be shit. I tried to revise it to actually work - but hopefully someone checks this work. 