### PR TITLE
Adding `mypy` to type check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,3 +35,10 @@ repos:
     hooks:
       - id: codespell
         additional_dependencies: [".[toml]"]
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.9.0
+    hooks:
+      - id: mypy
+        additional_dependencies: # Versions here match pyproject.toml
+          - aiohttp
+          - pytest

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,2 @@
 pytest
 pre-commit
-requests

--- a/paperscraper/lib.py
+++ b/paperscraper/lib.py
@@ -321,7 +321,7 @@ async def parse_semantic_scholar_metadata(paper: dict[str, Any]) -> dict[str, An
         "year": paper["year"],
         "url": paper["url"],
         "paperId": paper["paperId"],
-        "doi": paper["externalIds"].get("DOI", None),
+        "doi": paper["externalIds"].get("DOI"),
         "citationCount": paper["citationCount"],
         "title": paper["title"],
     }
@@ -331,7 +331,7 @@ async def parse_google_scholar_metadata(
     paper: dict[str, Any], session: ClientSession
 ) -> dict[str, Any]:
     """Parse raw paper metadata from Google Scholar into a more rich format."""
-    doi: str | None = paper["externalIds"].get("DOI", None)
+    doi: str | None = paper["externalIds"].get("DOI")
     if doi:
         try:
             bibtex = await doi_to_bibtex(doi, session)
@@ -367,7 +367,7 @@ async def parse_google_scholar_metadata(
         "year": paper["year"],
         "url": paper["link"],
         "paperId": paper["paperId"],
-        "doi": paper["externalIds"].get("DOI", None),
+        "doi": paper["externalIds"].get("DOI"),
         "citationCount": paper["citationCount"],
         "title": paper["title"],
     }

--- a/paperscraper/lib.py
+++ b/paperscraper/lib.py
@@ -608,7 +608,9 @@ async def a_search_papers(  # noqa: C901, PLR0912, PLR0915
         if "as_ylo" not in google_params:
             logger.warning(f"Could not parse year {year}")
 
-    paths = _paths or {}
+    paths: dict[str, dict[str, Any]] = (
+        {str(k): v for k, v in _paths.items()} if _paths is not None else {}
+    )
     scraper = scraper or default_scraper()
     ssheader = get_header()
     if semantic_scholar_api_key is not None:
@@ -680,11 +682,11 @@ async def a_search_papers(  # noqa: C901, PLR0912, PLR0915
                                 f" text {await response.text()!r}."
                             )
                             return None
-                        response = await response.json()  # noqa: PLW2901
+                        response_data = await response.json()
                     if (
-                        "data" not in response
+                        "data" not in response_data
                         and year is not None
-                        and response["total"] == 0
+                        and response_data["total"] == 0
                     ):
                         logger.info(
                             f"{title} | {year} not found. Now trying without year"
@@ -700,12 +702,14 @@ async def a_search_papers(  # noqa: C901, PLR0912, PLR0915
                                     f" status {resp.status}, reason {resp.reason},"
                                     f" text {await resp.text()!r}."
                                 )
-                            response = await resp.json()
-                    if "data" in response:
+                            response_data = await resp.json()
+                    if "data" in response_data:
                         if pdf_link is not None:
                             # Google Scholar url takes precedence
-                            response["data"][0]["openAccessPdf"] = {"url": pdf_link}
-                        return response["data"][0]
+                            response_data["data"][0]["openAccessPdf"] = {
+                                "url": pdf_link
+                            }
+                        return response_data["data"][0]
                     return None
 
                 responses = await asyncio.gather(
@@ -753,7 +757,7 @@ async def a_search_papers(  # noqa: C901, PLR0912, PLR0915
                 query,
                 limit=limit,
                 pdir=pdir,
-                _paths=paths,
+                _paths=paths,  # type: ignore[arg-type]
                 _limit=_limit,
                 _offset=_offset + (20 if search_type == "google" else _limit),
                 logger=logger,
@@ -821,7 +825,9 @@ async def a_gsearch_papers(  # noqa: C901, PLR0915
         if "as_ylo" not in params:
             logger.warning(f"Could not parse year {year}")
 
-    paths = _paths or {}
+    paths: dict[str, dict[str, Any]] = (
+        {str(k): v for k, v in _paths.items()} if _paths is not None else {}
+    )
     scraper = scraper or default_scraper()
     ssheader = get_header()
     # add key to headers
@@ -913,7 +919,7 @@ async def a_gsearch_papers(  # noqa: C901, PLR0915
                 query,
                 limit=limit,
                 pdir=pdir,
-                _paths=paths,
+                _paths=paths,  # type: ignore[arg-type]
                 _offset=_offset + limit,
                 _limit=_limit,
                 logger=logger,

--- a/paperscraper/log_formatter.py
+++ b/paperscraper/log_formatter.py
@@ -8,16 +8,16 @@ class CustomFormatter(logging.Formatter):
     red = "\x1b[31;20m"
     bold_red = "\x1b[31;1m"
     reset = "\x1b[0m"
-    format = (
+    format_str = (
         "%(asctime)s - %(name)s - %(levelname)s - %(message)s (%(filename)s:%(lineno)d)"
     )
 
     FORMATS = {  # noqa: RUF012
-        logging.DEBUG: grey + format + reset,
-        logging.INFO: grey + format + reset,
-        logging.WARNING: yellow + format + reset,
-        logging.ERROR: red + format + reset,
-        logging.CRITICAL: bold_red + format + reset,
+        logging.DEBUG: grey + format_str + reset,
+        logging.INFO: grey + format_str + reset,
+        logging.WARNING: yellow + format_str + reset,
+        logging.ERROR: red + format_str + reset,
+        logging.CRITICAL: bold_red + format_str + reset,
     }
 
     def format(self, record):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,59 @@ check-hidden = true
 ignore-regex = ".{1024}|.*codespell-ignore.*"
 ignore-words-list = "cros,ser"
 
+[tool.mypy]
+# Type-checks the interior of functions without type annotations.
+check_untyped_defs = true
+# Allows enabling one or multiple error codes globally. Note: This option will
+# override disabled error codes from the disable_error_code option.
+enable_error_code = [
+    "ignore-without-code",
+    "mutable-override",
+    "redundant-cast",
+    "redundant-expr",
+    "redundant-self",
+    "truthy-bool",
+    "truthy-iterable",
+    "unreachable",
+    "unused-ignore",
+]
+# Shows a short summary line after error messages.
+error_summary = false
+# A regular expression that matches file names, directory names and paths which mypy
+# should ignore while recursively discovering files to check. Use forward slashes (/) as
+# directory separators on all platforms.
+exclude = [
+    "^\\.?venv",  # SEE: https://regex101.com/r/0rp5Br/1
+]
+# Use visually nicer output in error messages: use soft word wrap, show source
+# code snippets, and show error location markers.
+pretty = true
+# Shows column numbers in error messages.
+show_column_numbers = true
+# Shows error codes in error messages.
+# SEE: https://mypy.readthedocs.io/en/stable/error_codes.html#error-codes
+show_error_codes = true
+# Prefixes each error with the relevant context.
+show_error_context = true
+# Warns about casting an expression to its inferred type.
+warn_redundant_casts = true
+# Shows a warning when encountering any code inferred to be unreachable or
+# redundant after performing type analysis.
+warn_unreachable = true
+# Warns about per-module sections in the config file that do not match any
+# files processed when invoking mypy.
+warn_unused_configs = true
+# Warns about unneeded `# type: ignore` comments.
+warn_unused_ignores = true
+
+[[tool.mypy.overrides]]
+# Suppresses error messages about imports that cannot be resolved.
+ignore_missing_imports = true
+# Per-module configuration options
+module = [
+    "pybtex.*",  # SEE: https://bitbucket.org/pybtex-devs/pybtex/issues/141/type-annotations
+]
+
 [tool.pytest.ini_options]
 # List of directories that should be searched for tests when no specific directories,
 # files or test ids are given in the command line when executing pytest from the rootdir

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,8 @@ warn_unused_ignores = true
 ignore_missing_imports = true
 # Per-module configuration options
 module = [
+    "fitz",  # SEE: https://github.com/pymupdf/PyMuPDF/issues/3361
+    "nest_asyncio",
     "pybtex.*",  # SEE: https://bitbucket.org/pybtex-devs/pybtex/issues/141/type-annotations
 ]
 

--- a/tests/test_paperscraper.py
+++ b/tests/test_paperscraper.py
@@ -269,7 +269,7 @@ class Test7(IsolatedAsyncioTestCase):
     async def test_custom_scraper(self):
         query = "covid vaccination"
         scraper = paperscraper.Scraper()
-        scraper = scraper.register_scraper(
+        scraper.register_scraper(
             lambda paper, path, **kwargs: None,  # noqa: ARG005
             priority=0,
             name="test",


### PR DESCRIPTION
https://github.com/blackadad/paper-scraper/pull/60 fixed a regression caused by my [PR suggestion](https://github.com/blackadad/paper-scraper/pull/58#discussion_r1555220153) that mixed up `status` and `status_code`. This could have been prevented if we had `mypy` in place.

This PR:
- Brings `mypy .` from 30+ errors to 0, fixing multiple latent bugs along the way
- Adds `mypy` to `pre-commit` with a `pyproject.toml` config
- Removes unused `requests` dependency from dev requirements
