### PR TITLE
Exposing `encode_id` function

### DIFF
--- a/paperscraper/lib.py
+++ b/paperscraper/lib.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-import hashlib
 import logging
 import os
 import re
@@ -19,7 +18,7 @@ from .exceptions import DOINotFoundError
 from .headers import get_header
 from .log_formatter import CustomFormatter
 from .scraper import Scraper
-from .utils import ThrottledClientSession, find_doi, get_hostname
+from .utils import ThrottledClientSession, encode_id, find_doi, get_hostname
 
 
 def clean_upbibtex(bibtex):
@@ -913,7 +912,7 @@ async def a_gsearch_papers(  # noqa: C901, PLR0915
                 paper["citationCount"] = int(paper["inline_links"]["cited_by"]["total"])
 
             # set paperId to be hex digest of doi
-            paper["paperId"] = hashlib.md5(doi.encode()).hexdigest()[0:16]  # noqa: S324
+            paper["paperId"] = encode_id(doi)
             return paper
 
         # we only process papers that have a link

--- a/paperscraper/utils.py
+++ b/paperscraper/utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import logging
 import os
 import random
@@ -10,6 +11,7 @@ import urllib.parse
 from collections.abc import Collection
 from logging import Logger
 from typing import cast
+from uuid import UUID
 
 import aiohttp
 import fitz
@@ -162,6 +164,15 @@ def find_doi(text: str) -> str | None:
     if not match:
         return None
     return match.group()
+
+
+def encode_id(value: str | bytes | UUID, maxsize: int | None = 16) -> str:
+    """Encode a value (e.g. a DOI) optionally with a max length."""
+    if isinstance(value, UUID):
+        value = str(value)
+    if isinstance(value, str):
+        value = value.encode()
+    return hashlib.md5(value).hexdigest()[:maxsize]  # noqa: S324
 
 
 def get_hostname(url):


### PR DESCRIPTION
Enabling downstream repos to reuse the encoding logic