### PR TITLE
Adding `pytest-timeout` for deadlocks

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,4 @@
 pytest
+pytest-timeout
 pre-commit
 requests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,11 +44,16 @@ ignore-regex = ".{1024}|.*codespell-ignore.*"
 ignore-words-list = "cros,ser"
 
 [tool.pytest.ini_options]
+# Timeout in seconds for entire session.  Default is None which means no timeout.
+# Timeout is checked between tests, and will not interrupt a test in progress.
+session_timeout = 1200
 # List of directories that should be searched for tests when no specific directories,
 # files or test ids are given in the command line when executing pytest from the rootdir
 # directory. File system paths may use shell-style wildcards, including the recursive **
 # pattern.
 testpaths = ["tests"]
+# Timeout in seconds before dumping the stacks. Default is 0 which means no timeout.
+timeout = 300
 
 [tool.ruff]
 # Line length to use when enforcing long-lines violations (like `E501`).


### PR DESCRIPTION
https://github.com/blackadad/paper-scraper/actions/runs/8604311827?pr=61 ran for 5.5-hrs until I noticed it and killed it

I am not sure where the deadlock happened, but to help debug in the future, I am adding https://github.com/pytest-dev/pytest-timeout to enforce:
- 5-min per-test case timeout
- 20-min overall timeout