### PR TITLE
Expanding `find_doi` to account for more papers

### DIFF
--- a/paperscraper/utils.py
+++ b/paperscraper/utils.py
@@ -143,23 +143,17 @@ def check_pdf(path: str | os.PathLike, verbose: bool | Logger = False) -> bool:
     return True
 
 
-pattern = r"10.\d{4,9}/[-._;():A-Z0-9]+"
+# SEE: https://www.crossref.org/blog/dois-and-matching-regular-expressions/
+# Test cases: https://regex101.com/r/xtI5bS/2
+pattern = r"10.\d{4,9}(?:[\/\.][a-z]*\d+[-;():\w]*)+"
 compiled_pattern = re.compile(pattern, re.IGNORECASE)
 
 
-def find_doi(text):
-    # https://www.crossref.org/blog/dois-and-matching-regular-expressions/
+def find_doi(text: str) -> str | None:
     match = compiled_pattern.search(text)
-    if match:
-        proposed = match.group()
-    else:
+    if not match:
         return None
-
-    # strip off any trailing marksers
-    proposed = proposed.replace(".abstract", "")
-    proposed = proposed.replace(".full-text", "")
-    proposed = proposed.replace(".full", "")
-    return proposed.replace(".pdf", "")
+    return match.group()
 
 
 def get_hostname(url):

--- a/tests/test_paperscraper.py
+++ b/tests/test_paperscraper.py
@@ -34,7 +34,7 @@ class TestCrossref(IsolatedAsyncioTestCase):
         assert format_bibtex(bibtex, key, clean=False)
 
 
-def test_find_doi():
+def test_find_doi() -> None:
     test_parameters = [
         ("https://www.sciencedirect.com/science/article/pii/S001046551930373X", None),
         ("https://doi.org/10.1056/nejmoa2200674", "10.1056/nejmoa2200674"),
@@ -49,6 +49,18 @@ def test_find_doi():
         (
             "https://www.taylorfrancis.com/chapters/edit/10.1201/9781003240037-2/impact-covid-vaccination-globe-using-data-analytics-pawan-whig-arun-velu-rahul-reddy-pavika-sharma",
             "10.1201/9781003240037-2",
+        ),
+        (
+            "https://iopscience.iop.org/article/10.7567/1882-0786/ab5c44/meta",
+            "10.7567/1882-0786/ab5c44",
+        ),
+        (
+            "https://iopscience.iop.org/article/10.7567/abc123abc/meta",
+            "10.7567/abc123abc",
+        ),
+        (
+            "https://iopscience.iop.org/article/10.7567/abc123abc.pdf",
+            "10.7567/abc123abc",
         ),
     ]
     for link, expected in test_parameters:

--- a/tests/test_paperscraper.py
+++ b/tests/test_paperscraper.py
@@ -18,11 +18,9 @@ from paperscraper.utils import ThrottledClientSession, find_doi
 
 
 class TestCrossref(IsolatedAsyncioTestCase):
-    async def test_reconcile_dois(self):
+    async def test_reconcile_dois(self) -> None:
         session = ThrottledClientSession(headers=get_header(), rate_limit=15 / 60)
-        link = "https://doi.org/10.1056/nejmoa2200674"
         doi = "10.1056/nejmoa2200674"
-        assert find_doi(link) == doi
 
         bibtex = await doi_to_bibtex(doi, session)
         assert bibtex


### PR DESCRIPTION
https://iopscience.iop.org/article/10.7567/1882-0786/ab5c44/meta broke our `find_doi` function.

This PR:

- Expands `find_doi`'s regex to hit this case, with test cases
- Removes a duplicate assertion in `test_reconcile_dois`
