### PR TITLE
Suppressing a `latexcodec` warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,12 @@ module = [
 ]
 
 [tool.pytest.ini_options]
+# Sets a list of filters and actions that should be taken for matched warnings.
+# By default all warnings emitted during the test session will be displayed in
+# a summary at the end of the test session.
+filterwarnings = [
+    'ignore:open_text is deprecated. Use files\(\) instead:DeprecationWarning',  # Remove after release of https://github.com/mcmtroffaes/latexcodec/issues/98 or closing of https://bitbucket.org/pybtex-devs/pybtex/issues/160/latexcodec-pylatexenc
+]
 # Timeout in seconds for entire session.  Default is None which means no timeout.
 # Timeout is checked between tests, and will not interrupt a test in progress.
 session_timeout = 1200


### PR DESCRIPTION
```
tests/test_paperscraper.py::TestCrossref::test_reconcile_dois
  /opt/hostedtoolcache/Python/3.12.2/x64/lib/python3.12/site-packages/latexcodec/codec.py:102: DeprecationWarning: open_text is deprecated. Use files() instead. Refer to https://importlib-resources.readthedocs.io/en/latest/using.html#migrating-from-legacy for migration advice.
    with pkg_resources.open_text('latexcodec', 'table.txt') as datafile:
```

This warning is outside of our control, so this PR just:
1. Documents what is needed to resolve it
2. Suppresses it in the meantime