### PR TITLE
Fixing misleading failure message in `find_pmc_pdf_link`

### DIFF
--- a/paperscraper/lib.py
+++ b/paperscraper/lib.py
@@ -172,13 +172,17 @@ async def link_to_pdf(url, path, session: ClientSession) -> None:  # noqa: C901
 async def find_pmc_pdf_link(pmc_id, session: ClientSession) -> str:
     url = f"https://www.ncbi.nlm.nih.gov/pmc/articles/PMC{pmc_id}"
     async with session.get(url) as r:
-        if not r.ok:
-            raise RuntimeError(f"No paper with pmc id {pmc_id}. {url} {r.status}")
+        try:
+            r.raise_for_status()
+        except ClientResponseError as exc:
+            raise RuntimeError(
+                f"Failed to download PubMed Central ID {pmc_id} from URL {url}."
+            ) from exc
         html_text = await r.text()
         pdf_link = re.search(r'href="(.*\.pdf)"', html_text)
         if pdf_link is None:
             raise RuntimeError(
-                f"No PDF link found for PubMed Central ID {pmc_id}. {url}"
+                f"No PDF link matched for PubMed Central ID {pmc_id} from URL {url}."
             )
         return f"https://www.ncbi.nlm.nih.gov{pdf_link.group(1)}"
 


### PR DESCRIPTION
https://github.com/blackadad/paper-scraper/actions/runs/8620164682/job/23626483846?pr=71

```none
E               RuntimeError: No paper with pmc id 5008462. https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5008462 403
```

Similar to https://github.com/blackadad/paper-scraper/pull/71, this PR fixes another misleading failure message

It also fixes a SIM105 mix up with pre-commit during https://github.com/blackadad/paper-scraper/pull/71