### PR TITLE
Fixing ChemRxiv in `find_doi`

### DIFF
--- a/paperscraper/utils.py
+++ b/paperscraper/utils.py
@@ -154,8 +154,8 @@ def check_pdf(path: str | os.PathLike, verbose: bool | Logger = False) -> bool:
 
 
 # SEE: https://www.crossref.org/blog/dois-and-matching-regular-expressions/
-# Test cases: https://regex101.com/r/xtI5bS/4
-pattern = r"10.\d{4,9}(?:[\/\.][a-z]*[\d.]+[-;():\w]*)+"
+# Test cases: https://regex101.com/r/xtI5bS/5
+pattern = r"10.\d{4,9}(?:[\/\.][a-z-]*[\d.]+[-;():\w]*)+"
 compiled_pattern = re.compile(pattern, re.IGNORECASE)
 
 

--- a/tests/test_paperscraper.py
+++ b/tests/test_paperscraper.py
@@ -112,6 +112,10 @@ def test_find_doi() -> None:
             "10.1016/j.arth.2005.04.023",
         ),
         ("https://doi.org/10.48550/arXiv.2401.00044", "10.48550/arXiv.2401.00044"),
+        (
+            "https://doi.org/10.26434/chemrxiv-2023-fw8n4-v3",
+            "10.26434/chemrxiv-2023-fw8n4-v3",
+        ),
     ]
     for link, expected in test_parameters:
         if expected is None:


### PR DESCRIPTION
Adds a case for ChemRxiv and expanded the regex further