### PR TITLE
Fixing URL encodings and bioRxiv in `find_doi`

### DIFF
--- a/paperscraper/utils.py
+++ b/paperscraper/utils.py
@@ -154,13 +154,13 @@ def check_pdf(path: str | os.PathLike, verbose: bool | Logger = False) -> bool:
 
 
 # SEE: https://www.crossref.org/blog/dois-and-matching-regular-expressions/
-# Test cases: https://regex101.com/r/xtI5bS/5
-pattern = r"10.\d{4,9}(?:[\/\.][a-z-]*[\d.]+[-;():\w]*)+"
+# Test cases: https://regex101.com/r/xtI5bS/7
+pattern = r"10.\d{4,9}(?:[\/\.][a-z-().]*(?:.[\d]+[-<>;():\w]*)+)+"
 compiled_pattern = re.compile(pattern, re.IGNORECASE)
 
 
 def find_doi(text: str) -> str | None:
-    match = compiled_pattern.search(text)
+    match = compiled_pattern.search(urllib.parse.unquote(text))
     if not match:
         return None
     return match.group()

--- a/tests/test_paperscraper.py
+++ b/tests/test_paperscraper.py
@@ -116,6 +116,18 @@ def test_find_doi() -> None:
             "https://doi.org/10.26434/chemrxiv-2023-fw8n4-v3",
             "10.26434/chemrxiv-2023-fw8n4-v3",
         ),
+        (
+            "https://www.biorxiv.org/content/10.1101/2022.08.05.502972.full.pdf",
+            "10.1101/2022.08.05.502972",
+        ),
+        (
+            "https://doi.org/10.1002/(SICI)1097-0177(200006)218:2%3C235::AID-DVDY2%3E3.0.CO;2-G",
+            "10.1002/(SICI)1097-0177(200006)218:2<235::AID-DVDY2>3.0.CO;2-G",
+        ),
+        (
+            "https://anatomypubs.onlinelibrary.wiley.com/doi/10.1002/(SICI)1097-0177(200006)218:2%3C235::AID-DVDY2%3E3.0.CO;2-G",
+            "10.1002/(SICI)1097-0177(200006)218:2<235::AID-DVDY2>3.0.CO;2-G",
+        ),
     ]
     for link, expected in test_parameters:
         if expected is None:


### PR DESCRIPTION
Adds cases for bioRxiv as well as URL encodings, and expanded the regex further