### PR TITLE
Fixing `rate_limit` being a requirement for backoff

### DIFF
--- a/paperscraper/utils.py
+++ b/paperscraper/utils.py
@@ -117,7 +117,7 @@ class ThrottledClientSession(aiohttp.ClientSession):
                 exp_backoff_with_jitter = 0.1 * (2**retry_num + random.random())
                 logger.warning(
                     f"Hit a service limit per status {response.status}, sleeping"
-                    f" {exp_backoff_with_jitter}-sec before retry {retry_num + 1}."
+                    f" {exp_backoff_with_jitter:.2f}-sec before retry {retry_num + 1}."
                 )
                 await asyncio.sleep(exp_backoff_with_jitter)
                 # NOTE: on next iteration, we have to wait again, which ensures


### PR DESCRIPTION
https://github.com/blackadad/paper-scraper/pull/47 coupled backoff to `rate_limit`, so https://github.com/blackadad/paper-scraper/pull/61 correctly made `rate_limit` a requirement for backoff. However, https://github.com/blackadad/paper-scraper/pull/69 removed backoff's coupling to `rate_limit`, so now we can remove `rate_limit` being a requirement for backoff.

Also, this PR truncates the sleep interval in the logged message