### PR TITLE
Fixing `format_bibtex` crash on BibTeX without author or title

### DIFF
--- a/paperscraper/exceptions.py
+++ b/paperscraper/exceptions.py
@@ -2,3 +2,7 @@ class DOINotFoundError(Exception):
     def __init__(self, message="DOI not found"):
         self.message = message
         super().__init__(self.message)
+
+
+class CitationConversionError(Exception):
+    """Exception to throw when we can't process a citation from a BibTeX."""

--- a/tests/test_paperscraper.py
+++ b/tests/test_paperscraper.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 import os
 import time
 from unittest import IsolatedAsyncioTestCase
@@ -8,7 +9,7 @@ import aiohttp
 from pybtex.database import parse_string
 
 import paperscraper
-from paperscraper.exceptions import DOINotFoundError
+from paperscraper.exceptions import CitationConversionError, DOINotFoundError
 from paperscraper.headers import get_header
 from paperscraper.lib import (
     RateLimits,
@@ -537,4 +538,6 @@ class Test16(IsolatedAsyncioTestCase):
         }
         """  # noqa: RUF001
         key: str = bibtex6.split("{")[1].split(",")[0]
-        format_bibtex(bibtex6, key, clean=False)
+        # Check callers can intuit this conversion's failure
+        with contextlib.suppress(CitationConversionError):
+            format_bibtex(bibtex6, key, clean=False)

--- a/tests/test_paperscraper.py
+++ b/tests/test_paperscraper.py
@@ -453,7 +453,7 @@ class Test15(IsolatedAsyncioTestCase):
 
 
 class Test16(IsolatedAsyncioTestCase):
-    def test_format_bibtex(self):
+    def test_format_bibtex(self) -> None:
         bibtex = """
             @['JournalArticle']{Salomón-Ferrer2013RoutineMM,
                 author = {Romelia Salomón-Ferrer and A. Götz and D. Poole and S. Le Grand and R. Walker},
@@ -521,3 +521,20 @@ class Test16(IsolatedAsyncioTestCase):
         """
 
         parse_string(clean_upbibtex(bibtex5), "bibtex")
+
+        # Edge case where there is no title or author
+        bibtex6 = """
+        @article{2023,
+            volume = {383},
+            ISSN = {0378-4274},
+            url = {http://dx.doi.org/10.1016/j.toxlet.2023.05.004},
+            DOI = {10.1016/j.toxlet.2023.05.004},
+            journal = {Toxicology Letters},
+            publisher = {Elsevier BV},
+            year = {2023},
+            month = jul,
+            pages = {33–42}
+        }
+        """  # noqa: RUF001
+        key: str = bibtex6.split("{")[1].split(",")[0]
+        format_bibtex(bibtex6, key, clean=False)


### PR DESCRIPTION
DOI 10.1016/j.toxlet.2023.05.004 from Crossref has no `title` or `author` in it. This breaks our current `format_bibtex` function, because it requires at least a `title`.

If we can't make a proper citation, then I think `format_bibtex` should not make up a halfway citation of just the title. Imo it should just return an empty string, which callers can use to posit failure (instead of giving a halfway citation).

This PR:
- Adds a new test case for the `format_bibtex` crash on 10.1016/j.toxlet.2023.05.004
- Brings about my comment above