### PR TITLE
Service limit reached message in backoff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v4.6.0
     hooks:
       - id: check-added-large-files
       - id: check-byte-order-marker
@@ -22,7 +22,7 @@ repos:
     hooks:
     - id: black-jupyter
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.3.5
+    rev: v0.3.6
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/paperscraper/utils.py
+++ b/paperscraper/utils.py
@@ -116,7 +116,8 @@ class ThrottledClientSession(aiohttp.ClientSession):
             if retry_num < self._retry_count:
                 exp_backoff_with_jitter = 0.1 * (2**retry_num + random.random())
                 logger.warning(
-                    f"Hit a service limit per status {response.status}, sleeping"
+                    f"Hit a service limit per status {response.status} with message"
+                    f" {await response.text()}, sleeping"
                     f" {exp_backoff_with_jitter:.2f}-sec before retry {retry_num + 1}."
                 )
                 await asyncio.sleep(exp_backoff_with_jitter)


### PR DESCRIPTION
Displaying the service limit reached's message in the backoff, for debugging. The message may present additional information on top of the status code.