### PR TITLE
More checks on serpapi return values

### DIFF
--- a/paperscraper/lib.py
+++ b/paperscraper/lib.py
@@ -383,7 +383,7 @@ async def preprocess_google_scholar_metadata(
     # set citation count
     paper["citationCount"] = (
         int(paper["inline_links"]["cited_by"]["total"])
-        if "cited_by" in paper["inline_links"]
+        if ("cited_by" in paper["inline_links"] and paper["inline_links"]["cited_by"]["total"])
         else 0  # best we can do
     )
 

--- a/paperscraper/lib.py
+++ b/paperscraper/lib.py
@@ -383,7 +383,10 @@ async def preprocess_google_scholar_metadata(
     # set citation count
     paper["citationCount"] = (
         int(paper["inline_links"]["cited_by"]["total"])
-        if ("cited_by" in paper["inline_links"] and paper["inline_links"]["cited_by"]["total"])
+        if (
+            "cited_by" in paper["inline_links"]
+            and paper["inline_links"]["cited_by"]["total"]
+        )
         else 0  # best we can do
     )
 


### PR DESCRIPTION
I guess `total` can be an empty string

Msg:
 int(paper["inline_links"]["cited_by"]["total"])
 TypeError: int() argument must be a string, a bytes-like object or a real number, not 'NoneType'