### PR TITLE
Doubling session timeout, self-documenting tests

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -20,8 +20,7 @@ jobs:
           python-version: 3.12
       - run: python -m pip install .[dev]
       - uses: pre-commit/action@v3.0.1
-      - name: test
-        run: pytest
+      - run: pytest --verbose
         env:
           SERPAPI_API_KEY: ${{ secrets.SERPAPI_API_KEY }}
           SEMANTIC_SCHOLAR_API_KEY: ${{ secrets.SEMANTIC_SCHOLAR_API_KEY }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,11 +18,11 @@ repos:
       - id: trailing-whitespace
         exclude: .gitignore
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.3.0
+    rev: 24.4.0
     hooks:
     - id: black-jupyter
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.3.6
+    rev: v0.3.7
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,4 @@
 pytest
 pytest-timeout
+pytest-timer
 pre-commit

--- a/paperscraper/lib.py
+++ b/paperscraper/lib.py
@@ -595,6 +595,9 @@ class SematicScholarSearchType(IntEnum):
         raise NotImplementedError
 
 
+GOOGLE_SEARCH_PAGE_SIZE = 20
+
+
 async def a_search_papers(  # noqa: C901, PLR0912, PLR0915
     query: str,
     limit: int = 10,
@@ -663,7 +666,7 @@ async def a_search_papers(  # noqa: C901, PLR0912, PLR0915
             "q": query,
             "api_key": os.environ["SERPAPI_API_KEY"],
             "engine": "google_scholar",
-            "num": 20,
+            "num": GOOGLE_SEARCH_PAGE_SIZE,
             "start": _offset,
             # TODO - add offset and limit here  # noqa: TD004
         }
@@ -855,7 +858,8 @@ async def a_search_papers(  # noqa: C901, PLR0912, PLR0915
                 pdir=pdir,
                 _paths=paths,  # type: ignore[arg-type]
                 _limit=_limit,
-                _offset=_offset + (20 if search_type == "google" else _limit),
+                _offset=_offset
+                + (GOOGLE_SEARCH_PAGE_SIZE if search_type == "google" else _limit),
                 logger=logger,
                 year=year,
                 verbose=verbose,

--- a/paperscraper/utils.py
+++ b/paperscraper/utils.py
@@ -114,7 +114,7 @@ class ThrottledClientSession(aiohttp.ClientSession):
             if response.status not in self.SERVICE_LIMIT_REACHED_STATUS_CODES:
                 break
             if retry_num < self._retry_count:
-                exp_backoff_with_jitter = 2**retry_num + random.random()
+                exp_backoff_with_jitter = 0.1 * (2**retry_num + random.random())
                 logger.warning(
                     f"Hit a service limit per status {response.status} with message"
                     f" {await response.text()}, sleeping"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,7 +109,7 @@ filterwarnings = [
 ]
 # Timeout in seconds for entire session.  Default is None which means no timeout.
 # Timeout is checked between tests, and will not interrupt a test in progress.
-session_timeout = 1200
+session_timeout = 2400
 # List of directories that should be searched for tests when no specific directories,
 # files or test ids are given in the command line when executing pytest from the rootdir
 # directory. File system paths may use shell-style wildcards, including the recursive **

--- a/tests/test_paperscraper.py
+++ b/tests/test_paperscraper.py
@@ -14,6 +14,7 @@ import paperscraper
 from paperscraper.exceptions import CitationConversionError, DOINotFoundError
 from paperscraper.headers import get_header
 from paperscraper.lib import (
+    GOOGLE_SEARCH_PAGE_SIZE,
     RateLimits,
     clean_upbibtex,
     doi_to_bibtex,
@@ -196,10 +197,14 @@ class Test0(IsolatedAsyncioTestCase):
                 assert len(papers) >= 3
 
     async def test_high_limit(self) -> None:
+        """Confirm we can pull in more than two pages of Google search results."""
         papers = await paperscraper.a_search_papers(
-            "molecular dynamics", search_type="google", year="2019-2023", limit=25
+            "molecular dynamics",
+            search_type="google",
+            year="2019-2023",
+            limit=int(2.1 * GOOGLE_SEARCH_PAGE_SIZE),
         )
-        assert len(papers) > 20
+        assert len(papers) > GOOGLE_SEARCH_PAGE_SIZE
 
 
 class TestGS(IsolatedAsyncioTestCase):

--- a/tests/test_paperscraper.py
+++ b/tests/test_paperscraper.py
@@ -207,7 +207,7 @@ class Test0(IsolatedAsyncioTestCase):
         assert len(papers) > GOOGLE_SEARCH_PAGE_SIZE
 
 
-class TestGS(IsolatedAsyncioTestCase):
+class TestGSearch(IsolatedAsyncioTestCase):
     async def test_gsearch(self):
         query = "molecular dynamics"
         papers = await paperscraper.a_gsearch_papers(query, year="2019-2023", limit=3)
@@ -223,11 +223,11 @@ class TestGS(IsolatedAsyncioTestCase):
             assert paper["citationCount"]
             assert paper["title"]
 
-    async def test_gsearch_high_limit(self) -> None:
+    async def test_multiple_batches(self) -> None:
         papers = await paperscraper.a_gsearch_papers(
-            "molecular dynamics", year="2019-2023", limit=45
+            "molecular dynamics", year="2019-2023", limit=5, _limit=2
         )
-        assert len(papers) > 20
+        assert len(papers) >= 5
 
     async def test_no_link_doesnt_crash_us(self) -> None:
         await paperscraper.a_gsearch_papers(


### PR DESCRIPTION
Building atop https://github.com/blackadad/paper-scraper/pull/87, this PR:
- Making `test_high_limit`s more intuitively documenting
- Doubled session timeout from 20-mins to 40-mins, since it should just be a failover
- Using `pytest-timer` with `--verbose` to show test status and timing better in CI