### PR TITLE
Excluding spaces from regex parsing of `href`

### DIFF
--- a/paperscraper/lib.py
+++ b/paperscraper/lib.py
@@ -146,12 +146,12 @@ async def link_to_pdf(url, path, session: ClientSession) -> None:  # noqa: C901
             return pdf_link.group(1)
         # maybe epdf
         # should have pdf somewhere (could not be at end)
-        epdf_link = re.search(r'href="(.*\.epdf)"', html_text)
+        epdf_link = re.search(r'href="(\S+\.epdf)"', html_text)
         if epdf_link:
             return epdf_link.group(1).replace("epdf", "pdf")
 
         # obvious thing
-        pdf_link = re.search(r'href="(.*pdf)"', html_text)
+        pdf_link = re.search(r'href="(\S+\.pdf)"', html_text)
         if pdf_link:
             return pdf_link.group(1)
 
@@ -190,7 +190,7 @@ async def find_pmc_pdf_link(pmc_id, session: ClientSession) -> str:
                 f"Failed to download PubMed Central ID {pmc_id} from URL {url}."
             ) from exc
         html_text = await r.text()
-        pdf_link = re.search(r'href="(.*\.pdf)"', html_text)
+        pdf_link = re.search(r'href="(\S+\.pdf)"', html_text)
         if pdf_link is None:
             raise RuntimeError(
                 f"No PDF link matched for PubMed Central ID {pmc_id} from URL {url}."


### PR DESCRIPTION
In https://github.com/blackadad/paper-scraper/actions/runs/8696480301/job/23849831299?pr=87 we failed to parse a URL because we allow spaces in the regex. Thus, this PR:
- Filters out spaces in the regex
- Adds a test case for it