### PR TITLE
Documenting max Google pagination size

### DIFF
--- a/paperscraper/lib.py
+++ b/paperscraper/lib.py
@@ -599,7 +599,9 @@ class SematicScholarSearchType(IntEnum):
         raise NotImplementedError
 
 
-GOOGLE_SEARCH_PAGE_SIZE = 20
+# The fact that 20 is actually the max value was not in the SERP API docs as
+# of 4/15/2024, but was determined by contacting SERP support
+GOOGLE_SEARCH_MAX_PAGE_SIZE = 20
 
 
 async def a_search_papers(  # noqa: C901, PLR0912, PLR0915
@@ -670,7 +672,7 @@ async def a_search_papers(  # noqa: C901, PLR0912, PLR0915
             "q": query,
             "api_key": os.environ["SERPAPI_API_KEY"],
             "engine": "google_scholar",
-            "num": GOOGLE_SEARCH_PAGE_SIZE,
+            "num": GOOGLE_SEARCH_MAX_PAGE_SIZE,
             "start": _offset,
             # TODO - add offset and limit here  # noqa: TD004
         }
@@ -863,7 +865,7 @@ async def a_search_papers(  # noqa: C901, PLR0912, PLR0915
                 _paths=paths,  # type: ignore[arg-type]
                 _limit=_limit,
                 _offset=_offset
-                + (GOOGLE_SEARCH_PAGE_SIZE if search_type == "google" else _limit),
+                + (GOOGLE_SEARCH_MAX_PAGE_SIZE if search_type == "google" else _limit),
                 logger=logger,
                 year=year,
                 verbose=verbose,
@@ -883,7 +885,7 @@ async def a_gsearch_papers(  # noqa: C901
     pdir: str | os.PathLike = os.curdir,
     _paths: dict[str | os.PathLike, dict[str, Any]] | None = None,
     _offset: int = 0,
-    _limit: int = GOOGLE_SEARCH_PAGE_SIZE,
+    _limit: int = GOOGLE_SEARCH_MAX_PAGE_SIZE,
     logger: logging.Logger | None = None,
     year: str | None = None,
     verbose: bool = False,

--- a/paperscraper/lib.py
+++ b/paperscraper/lib.py
@@ -121,11 +121,10 @@ async def xiv_to_pdf(doi, path, domain: str, session: ClientSession) -> None:
             return
 
 
-async def link_to_pdf(url, path, session: ClientSession) -> None:  # noqa: C901
+async def link_to_pdf(url, path, session: ClientSession) -> None:
     # download
     async with session.get(url, allow_redirects=True) as r:
-        if not r.ok:
-            raise RuntimeError(f"Unable to download {url}, status code {r.status}")
+        r.raise_for_status()
         if "pdf" in r.headers["Content-Type"]:
             with open(path, "wb") as f:  # noqa: ASYNC101
                 f.write(await r.read())
@@ -165,12 +164,7 @@ async def link_to_pdf(url, path, session: ClientSession) -> None:  # noqa: C901
 
     try:
         async with session.get(pdf_link, allow_redirects=True) as r:
-            try:
-                r.raise_for_status()
-            except ClientResponseError as exc:
-                raise RuntimeError(
-                    f"Failed to download PDF from URL {pdf_link!r}."
-                ) from exc
+            r.raise_for_status()
             if "pdf" in r.headers["Content-Type"]:
                 with open(path, "wb") as f:  # noqa: ASYNC101
                     f.write(await r.read())

--- a/tests/test_paperscraper.py
+++ b/tests/test_paperscraper.py
@@ -9,7 +9,6 @@ from unittest import IsolatedAsyncioTestCase
 from unittest.mock import MagicMock
 
 import aiohttp
-import pytest
 from pybtex.database import parse_string
 
 import paperscraper
@@ -296,7 +295,7 @@ class Test1(IsolatedAsyncioTestCase):
                     os.path.join(tmpdir, "test1.pdf"),
                     session,
                 )
-                with pytest.raises(RuntimeError, match="No PDF link"):
+                try:
                     # Confirm we can regex parse without a malformed URL error
                     await openaccess_scraper(
                         {
@@ -307,6 +306,10 @@ class Test1(IsolatedAsyncioTestCase):
                         os.path.join(tmpdir, "test2.pdf"),
                         session,
                     )
+                except RuntimeError as exc:
+                    assert "No PDF link" in str(exc)  # noqa: PT017
+                else:
+                    raise AssertionError("Expected to fail with a RuntimeError")
 
     async def test_pubmed_to_pdf(self):
         path = "test.pdf"

--- a/tests/test_paperscraper.py
+++ b/tests/test_paperscraper.py
@@ -16,7 +16,7 @@ import paperscraper
 from paperscraper.exceptions import CitationConversionError, DOINotFoundError
 from paperscraper.headers import get_header
 from paperscraper.lib import (
-    GOOGLE_SEARCH_PAGE_SIZE,
+    GOOGLE_SEARCH_MAX_PAGE_SIZE,
     RateLimits,
     clean_upbibtex,
     doi_to_bibtex,
@@ -203,9 +203,9 @@ class Test0(IsolatedAsyncioTestCase):
             "molecular dynamics",
             search_type="google",
             year="2019-2023",
-            limit=int(2.1 * GOOGLE_SEARCH_PAGE_SIZE),
+            limit=int(2.1 * GOOGLE_SEARCH_MAX_PAGE_SIZE),
         )
-        assert len(papers) > GOOGLE_SEARCH_PAGE_SIZE
+        assert len(papers) > GOOGLE_SEARCH_MAX_PAGE_SIZE
 
 
 class TestGSearch(IsolatedAsyncioTestCase):


### PR DESCRIPTION
- Documenting `_limit` of 20 is actually a max
- Removed extraneous `RuntimeError` casts in favor of `raise_for_status()`
- Removed `pytest` import I added in https://github.com/blackadad/paper-scraper/pull/90